### PR TITLE
Achieve coverage 100%

### DIFF
--- a/pydantictypes/string_to_optional_int.py
+++ b/pydantictypes/string_to_optional_int.py
@@ -57,13 +57,14 @@ def constringtooptionalint(  # noqa: PLR0913 pylint: disable=too-many-arguments
     """
     constraints = abstract_constringtooptionalint(strict=strict, gt=gt, ge=ge, lt=lt, le=le, multiple_of=multiple_of)
     before_validator = BeforeValidator(OptionalIntegerMustBeFromStr(int).validate)
-    if version_info >= (3, 11):
-        return Annotated[Optional[int], before_validator, Unpack[constraints]]  # type: ignore[return-value]
-    # Filter out None values
-    valid_constraints = tuple(c for c in constraints if c is not None)
-    # Reason: Cannot use star expression in index on Python 3.7 (syntax was added in Python 3.11)
-    annotations = (Optional[int], before_validator) + valid_constraints  # noqa: RUF005
-    return Annotated[annotations]  # type: ignore[return-value]
+    # Reason: Following block is tested in different workflows in GitHub Actions
+    if version_info < (3, 11):  # pragma: no cover
+        # Filter out None values
+        valid_constraints = tuple(c for c in constraints if c is not None)
+        # Reason: Cannot use star expression in index on Python 3.7 (syntax was added in Python 3.11)
+        annotations = (Optional[int], before_validator) + valid_constraints  # noqa: RUF005
+        return Annotated[annotations]  # type: ignore[return-value]
+    return Annotated[Optional[int], before_validator, Unpack[constraints]]  # type: ignore[return-value]
 
 
 ConstrainedStringToOptionalInt = Annotated[

--- a/pydantictypes/string_with_comma_to_optional_int.py
+++ b/pydantictypes/string_with_comma_to_optional_int.py
@@ -54,13 +54,14 @@ def constringwithcommatooptionalint(  # noqa: PLR0913 pylint: disable=too-many-a
     """
     constraints = abstract_constringtooptionalint(strict=strict, gt=gt, ge=ge, lt=lt, le=le, multiple_of=multiple_of)
     before_validator = BeforeValidator(OptionalIntegerMustBeFromStr(Utility.convert_string_with_comma_to_int).validate)
-    if version_info >= (3, 11):
-        return Annotated[Optional[int], before_validator, Unpack[constraints]]  # type: ignore[return-value]
-    # Filter out None values
-    valid_constraints = tuple(c for c in constraints if c is not None)
-    # Reason: Cannot use star expression in index on Python 3.7 (syntax was added in Python 3.11)
-    annotations = (Optional[int], before_validator) + valid_constraints  # noqa: RUF005
-    return Annotated[annotations]  # type: ignore[return-value]
+    # Reason: Following block is tested in different workflows in GitHub Actions
+    if version_info < (3, 11):  # pragma: no cover
+        # Filter out None values
+        valid_constraints = tuple(c for c in constraints if c is not None)
+        # Reason: Cannot use star expression in index on Python 3.7 (syntax was added in Python 3.11)
+        annotations = (Optional[int], before_validator) + valid_constraints  # noqa: RUF005
+        return Annotated[annotations]  # type: ignore[return-value]
+    return Annotated[Optional[int], before_validator, Unpack[constraints]]  # type: ignore[return-value]
 
 
 StrictStringWithCommaToOptionalInt = Annotated[


### PR DESCRIPTION
This pull request updates two functions in the `pydantictypes` package to improve compatibility across Python versions and ensure proper handling of constraints. The changes primarily focus on conditional logic for Python version compatibility and handling annotations.

### Compatibility improvements for Python versions:

* [`pydantictypes/string_to_optional_int.py`](diffhunk://#diff-8a4288ef39745b377c8ebbffacdf9c729f094d1168d91a9da9f395967433bfc5L60-R67): Adjusted the `constringtooptionalint` function to handle constraints differently for Python versions below 3.11, while maintaining the original behavior for versions 3.11 and above. Added a `# pragma: no cover` comment to exclude version-specific logic from coverage tests.
* [`pydantictypes/string_with_comma_to_optional_int.py`](diffhunk://#diff-ddba3f425430b540a93e0481c4d574756c80cec3c4b6421cd3d3e688b44270c5L57-R64): Updated the `constringwithcommatooptionalint` function with similar adjustments for Python version compatibility and excluded version-specific logic from coverage tests using `# pragma: no cover`.