### PR TITLE
Add new types

### DIFF
--- a/pydantictypes/__init__.py
+++ b/pydantictypes/__init__.py
@@ -1,9 +1,12 @@
 """Top-level package for Pydantic Types."""
 
+from pydantictypes.empty_string_to_none import *  # noqa: F403
 from pydantictypes.half_width_string import *  # noqa: F403
 from pydantictypes.kanji_yen_string_to_int import *  # noqa: F403
 from pydantictypes.string_to_datetime import *  # noqa: F403
+from pydantictypes.string_to_optional_bool import *  # noqa: F403
 from pydantictypes.string_to_optional_int import *  # noqa: F403
+from pydantictypes.string_to_optional_str import *  # noqa: F403
 from pydantictypes.string_with_comma_to_int import *  # noqa: F403
 from pydantictypes.string_with_comma_to_optional_int import *  # noqa: F403
 from pydantictypes.string_with_length_constraint import *  # noqa: F403
@@ -12,10 +15,13 @@ from pydantictypes.symbol_yen_string_to_int import *  # noqa: F403
 __version__ = "1.1.0"
 
 __all__ = []
+__all__ += empty_string_to_none.__all__  # type:ignore[name-defined] # noqa: F405 pylint: disable=undefined-variable
 __all__ += half_width_string.__all__  # type:ignore[name-defined] # noqa: F405 pylint: disable=undefined-variable
 __all__ += kanji_yen_string_to_int.__all__  # type:ignore[name-defined] # noqa: F405 pylint: disable=undefined-variable
 __all__ += string_to_datetime.__all__  # type:ignore[name-defined] # noqa: F405 pylint: disable=undefined-variable
+__all__ += string_to_optional_bool.__all__  # type:ignore[name-defined] # noqa: F405 pylint: disable=undefined-variable
 __all__ += string_to_optional_int.__all__  # type:ignore[name-defined] # noqa: F405 pylint: disable=undefined-variable
+__all__ += string_to_optional_str.__all__  # type:ignore[name-defined] # noqa: F405 pylint: disable=undefined-variable
 __all__ += string_with_comma_to_int.__all__  # type:ignore[name-defined] # noqa: F405 pylint: disable=undefined-variable
 __all__ += string_with_comma_to_optional_int.__all__  # type:ignore[name-defined] # noqa: F405 pylint: disable=undefined-variable
 __all__ += string_with_length_constraint.__all__  # type:ignore[name-defined] # noqa: F405 pylint: disable=undefined-variable

--- a/pydantictypes/empty_string_to_none.py
+++ b/pydantictypes/empty_string_to_none.py
@@ -1,0 +1,49 @@
+"""Custom data type to validate empty string to None."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BeforeValidator
+
+# Reason: To use raw typing imports
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
+
+__all__ = [
+    "EmptyStringToNone",
+]
+
+
+class EmptyStringToNoneValidator:
+    """Validator that only accepts empty strings and converts them to None."""
+
+    # Reason: The argument of pydantic type
+    def validate(self, value: Any) -> None:  # noqa: ANN401
+        """Validate that value is an empty string and convert to None.
+
+        Args:
+            value: The value to validate.
+
+        Returns:
+            None if value is an empty string.
+
+        Raises:
+            TypeError: If value is not a string.
+            ValueError: If value is not an empty string.
+        """
+        if not isinstance(value, str):
+            msg = f"String required. Value is {value}. Type is {type(value)}."
+            raise TypeError(msg)
+        if value == "":
+            return
+        msg = "Value must be an empty string ''"
+        raise ValueError(msg)
+
+
+EmptyStringToNone = Annotated[
+    None,
+    BeforeValidator(EmptyStringToNoneValidator().validate),
+]

--- a/pydantictypes/string_to_optional_bool.py
+++ b/pydantictypes/string_to_optional_bool.py
@@ -1,0 +1,82 @@
+"""Custom data type to convert string to optional bool."""
+
+from __future__ import annotations
+
+from enum import Flag
+from typing import Any
+from typing import ClassVar
+from typing import Optional
+
+from pydantic import BeforeValidator
+
+# Reason: To use raw typing imports
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
+
+__all__ = [
+    "StringToBoolean",
+    "StringToOptionalBool",
+]
+
+
+class StringToBoolean(Flag):
+    """Boolean representation with string serialization.
+
+    This Flag enum represents boolean values that can be serialized to strings "1" (True) and "0" (False).
+    """
+
+    TRUE = True
+    FALSE = False
+
+    def __str__(self) -> str:
+        """Convert to string representation.
+
+        Returns:
+            "1" for True, "0" for False.
+        """
+        return "1" if self.value else "0"
+
+
+class StringToOptionalBoolValidator:
+    """Validator to convert string to optional boolean."""
+
+    # Mapping from string values to their boolean representations
+    _VALUE_MAP: ClassVar[dict[str, StringToBoolean | None]] = {
+        "1": StringToBoolean.TRUE,
+        "0": StringToBoolean.FALSE,
+        "": None,
+    }
+
+    # Reason: The argument of pydantic type
+    def validate(self, value: Any) -> StringToBoolean | None:  # noqa: ANN401
+        """Validate and convert string to optional boolean.
+
+        Args:
+            value: The value to validate (expected to be "1", "0", or "").
+
+        Returns:
+            StringToBoolean.TRUE if value is "1",
+            StringToBoolean.FALSE if value is "0",
+            None if value is "".
+
+        Raises:
+            TypeError: If value is not a string.
+            ValueError: If value is not "1", "0", or "".
+        """
+        if not isinstance(value, str):
+            msg = f"String required. Value is {value}. Type is {type(value)}."
+            raise TypeError(msg)
+
+        if value not in self._VALUE_MAP:
+            msg = "Value must be '1', '0', or ''"
+            raise ValueError(msg)
+
+        return self._VALUE_MAP[value]
+
+
+StringToOptionalBool = Annotated[
+    Optional[StringToBoolean],
+    BeforeValidator(StringToOptionalBoolValidator().validate),
+]

--- a/pydantictypes/string_to_optional_str.py
+++ b/pydantictypes/string_to_optional_str.py
@@ -1,0 +1,171 @@
+"""Custom data type to convert string to optional str with constraints."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+from typing import Optional
+from typing import Pattern
+
+from pydantic import BeforeValidator
+
+from pydantictypes._validation_utils import validate_optional_string_type
+
+# Reason: To use raw typing imports
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
+
+__all__ = [
+    "StringToOptionalStr",
+    "constringtooptionalstr",
+]
+
+
+class StringToOptionalStrValidator:
+    """Validator for optional string with constraints."""
+
+    # Reason: Following Pydantic specification.
+    def __init__(  # noqa: PLR0913 pylint: disable=too-many-arguments
+        self,
+        *,
+        strip_whitespace: bool = False,
+        to_lower: bool = False,
+        strict: bool = False,
+        min_length: int | None = None,
+        max_length: int | None = None,
+        curtail_length: int | None = None,
+        regex: str | Pattern[str] | None = None,
+    ) -> None:
+        self.strip_whitespace = strip_whitespace
+        self.to_lower = to_lower
+        self.strict = strict
+        self.min_length = min_length
+        self.max_length = max_length
+        self.curtail_length = curtail_length
+        self.regex = re.compile(regex) if isinstance(regex, str) else regex
+
+    def _apply_transformations(self, value: str) -> str:
+        """Apply transformations to the string.
+
+        Args:
+            value: The string to transform.
+
+        Returns:
+            The transformed string.
+        """
+        if self.strip_whitespace:
+            value = value.strip()
+
+        if self.to_lower:
+            value = value.lower()
+
+        if self.curtail_length is not None:
+            value = value[: self.curtail_length]
+
+        return value
+
+    def _validate_length(self, value: str) -> None:
+        """Validate string length constraints.
+
+        Args:
+            value: The string to validate.
+
+        Raises:
+            ValueError: If the string does not meet length constraints.
+        """
+        length = len(value)
+
+        if self.min_length is not None and length < self.min_length:
+            msg = f"String length must be at least {self.min_length}"
+            raise ValueError(msg)
+
+        if self.max_length is not None and length > self.max_length:
+            msg = f"String length must be at most {self.max_length}"
+            raise ValueError(msg)
+
+    def _validate_pattern(self, value: str) -> None:
+        """Validate string against regex pattern.
+
+        Args:
+            value: The string to validate.
+
+        Raises:
+            ValueError: If the string does not match the pattern.
+        """
+        if self.regex is not None and not self.regex.match(value):
+            msg = f"String does not match pattern {self.regex.pattern}"
+            raise ValueError(msg)
+
+    # Reason: The argument of pydantic type
+    def validate(self, value: Any) -> str | None:  # noqa: ANN401
+        """Validate optional string with constraints.
+
+        Args:
+            value: The value to validate.
+
+        Returns:
+            The validated and processed string or None if empty.
+
+        Raises:
+            TypeError: If value is not a string.
+            ValueError: If value does not meet the constraints.
+        """
+        if value is None:
+            msg = f"String required. Value is {value}. Type is {type(value)}."
+            raise TypeError(msg)
+
+        validated = validate_optional_string_type(value)
+        if validated is None:
+            return None
+
+        validated = self._apply_transformations(validated)
+        self._validate_length(validated)
+        self._validate_pattern(validated)
+
+        return validated
+
+
+StringToOptionalStr = Annotated[
+    Optional[str],
+    BeforeValidator(StringToOptionalStrValidator().validate),
+]
+
+
+# Reason: Followed Pydantic specification.
+def constringtooptionalstr(  # noqa: PLR0913 pylint: disable=too-many-arguments
+    *,
+    strip_whitespace: bool = False,
+    to_lower: bool = False,
+    strict: bool = False,
+    min_length: int | None = None,
+    max_length: int | None = None,
+    curtail_length: int | None = None,
+    regex: str | None = None,
+) -> type[str | None]:
+    """A wrapper around `Optional[str]` that allows for additional constraints.
+
+    Args:
+        strip_whitespace: Whether to strip leading and trailing whitespace. Defaults to False.
+        to_lower: Whether to convert the string to lowercase. Defaults to False.
+        strict: Whether to validate in strict mode (currently unused). Defaults to False.
+        min_length: The minimum length of the string.
+        max_length: The maximum length of the string.
+        curtail_length: The maximum length to truncate the string to.
+        regex: A regular expression pattern the string must match.
+
+    Returns:
+        The wrapped optional string type.
+    """
+    validator = StringToOptionalStrValidator(
+        strip_whitespace=strip_whitespace,
+        to_lower=to_lower,
+        strict=strict,
+        min_length=min_length,
+        max_length=max_length,
+        curtail_length=curtail_length,
+        regex=regex,
+    )
+    before_validator = BeforeValidator(validator.validate)
+    return Annotated[Optional[str], before_validator]  # type: ignore[return-value]

--- a/tests/pydantictypes/test_empty_string_to_none.py
+++ b/tests/pydantictypes/test_empty_string_to_none.py
@@ -1,0 +1,66 @@
+"""Tests for empty_string_to_none.py."""
+
+from __future__ import annotations
+
+import datetime
+from typing import TYPE_CHECKING
+from typing import Any
+
+import pytest
+from pydantic.dataclasses import dataclass
+from pydantic_core import ValidationError
+
+from pydantictypes.empty_string_to_none import EmptyStringToNone  # noqa: TC001
+from tests.pydantictypes import BaseTestImportFallback
+from tests.pydantictypes import create
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+@dataclass
+class Stub:
+    value: EmptyStringToNone
+
+
+class Test:
+    """Tests for EmptyStringToNone."""
+
+    def test_empty_string_converts_to_none(self) -> None:
+        """Empty string should be converted to None."""
+        stub = create(Stub, [""])
+        assert stub.value is None
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "1",
+            "non-empty",
+            " ",
+            "0",
+            None,
+            datetime.date(2020, 1, 1),
+            1,
+            0,
+        ],
+    )
+    # Reason: Need Any to test various invalid types in parametrized test
+    def test_error(self, value: Any) -> None:  # noqa: ANN401
+        """Only empty string should be accepted."""
+        with pytest.raises((ValidationError, TypeError, ValueError)):
+            create(Stub, [value])
+
+
+class TestImportFallback(BaseTestImportFallback):
+    """Tests for import fallback scenarios."""
+
+    def get_module(self) -> ModuleType:
+        """Return the module to test for import fallback."""
+        # Reason: For testing import fallback behavior
+        from pydantictypes import empty_string_to_none  # pylint: disable=import-outside-toplevel  # noqa: PLC0415
+
+        return empty_string_to_none
+
+    def supports_unpack_fallback(self) -> bool:
+        """This module does not support Unpack fallback testing."""
+        return False

--- a/tests/pydantictypes/test_half_width_string.py
+++ b/tests/pydantictypes/test_half_width_string.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from pydantic.dataclasses import dataclass
 from pydantic_core import ValidationError
@@ -9,7 +11,11 @@ from pydantic_core import ValidationError
 # Reason: These are used in dataclass field annotations which require runtime availability
 from pydantictypes.half_width_string import HalfWidthString  # noqa: TC001
 from pydantictypes.half_width_string import OptionalHalfWidthString  # noqa: TC001
+from tests.pydantictypes import BaseTestImportFallback
 from tests.pydantictypes import create
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 
 @dataclass
@@ -177,3 +183,18 @@ class TestEastAsianWidthCategories:
         # Note: The specific characters that are ambiguous depend on the Unicode version
         # We test the behavior exists even if specific examples may vary
         # Ambiguous characters behavior is tested indirectly
+
+
+class TestImportFallback(BaseTestImportFallback):
+    """Tests for import fallback scenarios."""
+
+    def get_module(self) -> ModuleType:
+        """Return the module to test for import fallback."""
+        # Reason: For testing import fallback behavior
+        from pydantictypes import half_width_string  # pylint: disable=import-outside-toplevel  # noqa: PLC0415
+
+        return half_width_string
+
+    def supports_unpack_fallback(self) -> bool:
+        """This module does not support Unpack fallback testing."""
+        return False

--- a/tests/pydantictypes/test_string_to_optional_bool.py
+++ b/tests/pydantictypes/test_string_to_optional_bool.py
@@ -1,0 +1,106 @@
+"""Tests for string_to_optional_bool.py."""
+
+from __future__ import annotations
+
+import datetime
+from typing import TYPE_CHECKING
+from typing import Any
+
+import pytest
+from pydantic.dataclasses import dataclass
+from pydantic_core import ValidationError
+
+from pydantictypes.string_to_optional_bool import StringToBoolean
+from pydantictypes.string_to_optional_bool import StringToOptionalBool
+from tests.pydantictypes import BaseTestImportFallback
+from tests.pydantictypes import create
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+@dataclass
+class Stub:
+    value: StringToOptionalBool
+
+
+class TestStringToBoolean:
+    """Tests for StringToBoolean enum."""
+
+    def test_true_value(self) -> None:
+        """Test True value."""
+        assert StringToBoolean(value=True).value is True
+
+    def test_false_value(self) -> None:
+        """Test False value."""
+        assert StringToBoolean(value=False).value is False
+
+    def test_str_true(self) -> None:
+        """Test string representation of True."""
+        assert str(StringToBoolean(value=True)) == "1"
+
+    def test_str_false(self) -> None:
+        """Test string representation of False."""
+        assert str(StringToBoolean(value=False)) == "0"
+
+
+class Test:
+    """Tests for StringToOptionalBool."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("1", StringToBoolean(value=True)),
+            ("0", StringToBoolean(value=False)),
+            ("", None),
+        ],
+    )
+    def test(self, value: str, expected: StringToBoolean | None) -> None:
+        """Property should be converted to optional bool."""
+        stub = create(Stub, [value])
+        if expected is None:
+            assert stub.value is None
+        else:
+            assert isinstance(stub.value, StringToBoolean)
+            assert stub.value.value == expected.value
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "true",
+            "false",
+            "True",
+            "False",
+            "yes",
+            "no",
+            "2",
+            "-1",
+            " ",
+            None,
+            datetime.date(2020, 1, 1),
+            1,
+            0,
+            True,
+            False,
+        ],
+    )
+    # Reason: Need Any to test various invalid types in parametrized test
+    def test_error(self, value: Any) -> None:  # noqa: ANN401
+        """Only '1', '0', or '' should be accepted."""
+        with pytest.raises((ValidationError, TypeError, ValueError)):
+            create(Stub, [value])
+
+
+class TestImportFallback(BaseTestImportFallback):
+    """Tests for import fallback scenarios."""
+
+    def get_module(self) -> ModuleType:
+        """Return the module to test for import fallback."""
+        # Reason: For testing import fallback behavior
+        from pydantictypes import string_to_optional_bool  # pylint: disable=import-outside-toplevel  # noqa: PLC0415
+
+        return string_to_optional_bool
+
+    def supports_unpack_fallback(self) -> bool:
+        """This module does not support Unpack fallback testing."""
+        return False

--- a/tests/pydantictypes/test_string_to_optional_str.py
+++ b/tests/pydantictypes/test_string_to_optional_str.py
@@ -1,0 +1,178 @@
+"""Tests for string_to_optional_str.py."""
+
+from __future__ import annotations
+
+import datetime
+from typing import TYPE_CHECKING
+from typing import Any
+
+import pytest
+from pydantic.dataclasses import dataclass
+from pydantic_core import ValidationError
+
+from pydantictypes.string_to_optional_str import StringToOptionalStr  # noqa: TC001
+from pydantictypes.string_to_optional_str import constringtooptionalstr  # noqa: TC001
+from tests.pydantictypes import BaseTestImportFallback
+from tests.pydantictypes import create
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+@dataclass
+class Stub:
+    value: StringToOptionalStr
+
+
+class Test:
+    """Tests for StringToOptionalStr."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("hello", "hello"),
+            ("world", "world"),
+            ("123", "123"),
+            ("", None),
+        ],
+    )
+    def test(self, value: str, expected: str | None) -> None:
+        """Property should be converted to optional str."""
+        stub = create(Stub, [value])
+        assert stub.value == expected
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            None,
+            datetime.date(2020, 1, 1),
+            1,
+            123,
+            True,
+            False,
+        ],
+    )
+    # Reason: Need Any to test various invalid types in parametrized test
+    def test_error(self, value: Any) -> None:  # noqa: ANN401
+        """Only string should be accepted."""
+        with pytest.raises((ValidationError, TypeError)):
+            create(Stub, [value])
+
+
+class TestConstraints:
+    """Tests for constringtooptionalstr with various constraints."""
+
+    def test_strip_whitespace(self) -> None:
+        """Test strip_whitespace constraint."""
+
+        @dataclass
+        class StubStrip:
+            value: constringtooptionalstr(strip_whitespace=True)  # type: ignore[valid-type]
+
+        stub = create(StubStrip, ["  hello  "])
+        assert stub.value == "hello"
+
+    def test_to_lower(self) -> None:
+        """Test to_lower constraint."""
+
+        @dataclass
+        class StubLower:
+            value: constringtooptionalstr(to_lower=True)  # type: ignore[valid-type]
+
+        stub = create(StubLower, ["HELLO"])
+        assert stub.value == "hello"
+
+    def test_min_length(self) -> None:
+        """Test min_length constraint."""
+
+        @dataclass
+        class StubMinLength:
+            value: constringtooptionalstr(min_length=5)  # type: ignore[valid-type]
+
+        stub = create(StubMinLength, ["hello"])
+        assert stub.value == "hello"
+
+        with pytest.raises(ValidationError):
+            create(StubMinLength, ["hi"])
+
+    def test_max_length(self) -> None:
+        """Test max_length constraint."""
+
+        @dataclass
+        class StubMaxLength:
+            value: constringtooptionalstr(max_length=5)  # type: ignore[valid-type]
+
+        stub = create(StubMaxLength, ["hello"])
+        assert stub.value == "hello"
+
+        with pytest.raises(ValidationError):
+            create(StubMaxLength, ["toolong"])
+
+    def test_curtail_length(self) -> None:
+        """Test curtail_length constraint."""
+
+        @dataclass
+        class StubCurtail:
+            value: constringtooptionalstr(curtail_length=5)  # type: ignore[valid-type]
+
+        stub = create(StubCurtail, ["hello world"])
+        assert stub.value == "hello"
+
+    def test_regex(self) -> None:
+        """Test regex constraint."""
+
+        @dataclass
+        class StubRegex:
+            value: constringtooptionalstr(regex=r"^[0-9]{3}$")  # type: ignore[valid-type]  # noqa: F722,RUF100
+
+        stub = create(StubRegex, ["123"])
+        assert stub.value == "123"
+
+        with pytest.raises(ValidationError):
+            create(StubRegex, ["abc"])
+
+        with pytest.raises(ValidationError):
+            create(StubRegex, ["1234"])
+
+    def test_combined_constraints(self) -> None:
+        """Test multiple constraints combined."""
+
+        @dataclass
+        class StubCombined:
+            value: constringtooptionalstr(  # type: ignore[valid-type]
+                strip_whitespace=True,
+                to_lower=True,
+                min_length=3,
+                max_length=10,
+            )
+
+        stub = create(StubCombined, ["  HELLO  "])
+        assert stub.value == "hello"
+
+        with pytest.raises(ValidationError):
+            create(StubCombined, ["  HI  "])  # Too short after stripping
+
+    def test_empty_string_returns_none(self) -> None:
+        """Test that empty string returns None with constraints."""
+
+        @dataclass
+        class StubEmpty:
+            value: constringtooptionalstr(min_length=5)  # type: ignore[valid-type]
+
+        stub = create(StubEmpty, [""])
+        assert stub.value is None
+
+
+class TestImportFallback(BaseTestImportFallback):
+    """Tests for import fallback scenarios."""
+
+    def get_module(self) -> ModuleType:
+        """Return the module to test for import fallback."""
+        # Reason: For testing import fallback behavior
+        from pydantictypes import string_to_optional_str  # pylint: disable=import-outside-toplevel  # noqa: PLC0415
+
+        return string_to_optional_str
+
+    def supports_unpack_fallback(self) -> bool:
+        """This module does not support Unpack fallback testing."""
+        return False

--- a/tests/pydantictypes/test_string_with_length_constraint.py
+++ b/tests/pydantictypes/test_string_with_length_constraint.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from pydantic.dataclasses import dataclass
 from pydantic_core import ValidationError
@@ -11,7 +13,11 @@ from pydantictypes.string_with_length_constraint import ConstrainedOptionalStrin
 from pydantictypes.string_with_length_constraint import ConstrainedStringWithLength  # noqa: TC001
 from pydantictypes.string_with_length_constraint import constrained_optional_string  # noqa: TC001
 from pydantictypes.string_with_length_constraint import constrained_string  # noqa: TC001
+from tests.pydantictypes import BaseTestImportFallback
 from tests.pydantictypes import create
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 
 @dataclass
@@ -239,3 +245,18 @@ class TestConstrainedOptionalStringFunction:
 
         with pytest.raises(ValidationError):
             create(Stub, ["abcdef"])
+
+
+class TestImportFallback(BaseTestImportFallback):
+    """Tests for import fallback scenarios."""
+
+    def get_module(self) -> ModuleType:
+        """Return the module to test for import fallback."""
+        # Reason: For testing import fallback behavior
+        from pydantictypes import string_with_length_constraint  # pylint: disable=import-outside-toplevel  # noqa: PLC0415,I001
+
+        return string_with_length_constraint
+
+    def supports_unpack_fallback(self) -> bool:
+        """This module does not support Unpack fallback testing."""
+        return False


### PR DESCRIPTION
This pull request introduces three new custom Pydantic data types—`EmptyStringToNone`, `StringToOptionalBool`, and `StringToOptionalStr`—along with their validators and comprehensive test coverage. These types provide new validation and conversion utilities for handling empty strings, string-to-boolean conversion, and optional string fields with constraints. The changes also update the package's public API to include these new types.

**New Data Types and Validators:**

* Added `EmptyStringToNone` type and validator, which converts empty strings to `None` and raises errors for non-empty or non-string values.
* Added `StringToOptionalBool` type and validator, supporting conversion of `"1"`, `"0"`, and `""` strings to optional boolean enum values, along with a custom `StringToBoolean` enum.
* Added `StringToOptionalStr` type and validator, supporting optional strings with constraints (e.g., min/max length, regex, lowercasing, whitespace stripping) and a `constringtooptionalstr` helper for easy configuration.

**Public API and Package Initialization:**

* Updated `pydantictypes/__init__.py` to import and expose the new types and their `__all__` symbols, making them available for users of the package. [[1]](diffhunk://#diff-0e691022ac8518936703afdd6565a642022a78476fb70e83fea20c71e5728f08R3-R9) [[2]](diffhunk://#diff-0e691022ac8518936703afdd6565a642022a78476fb70e83fea20c71e5728f08R18-R24)

**Testing and Import Fallbacks:**

* Added comprehensive tests for each new type, covering correct conversions, error handling, and constraint enforcement (`tests/pydantictypes/test_empty_string_to_none.py`, `tests/pydantictypes/test_string_to_optional_bool.py`, `tests/pydantictypes/test_string_to_optional_str.py`). [[1]](diffhunk://#diff-89a3e80779cc3a73756bfdb4fe74bd7180995f1ee62e14e2e8441eb8032ab3faR1-R66) [[2]](diffhunk://#diff-c9804832bf4efe96c81a2db7ebd8806621d14425e4feeeee56353547598a2e58R1-R106) [[3]](diffhunk://#diff-74ad497c05427bf9fd890d9044905ecdc6eb12533763992d5d984e7a2e22bd75R1-R178)
* Extended test files to include import fallback checks for compatibility and robustness. [[1]](diffhunk://#diff-89a3e80779cc3a73756bfdb4fe74bd7180995f1ee62e14e2e8441eb8032ab3faR1-R66) [[2]](diffhunk://#diff-c9804832bf4efe96c81a2db7ebd8806621d14425e4feeeee56353547598a2e58R1-R106) [[3]](diffhunk://#diff-74ad497c05427bf9fd890d9044905ecdc6eb12533763992d5d984e7a2e22bd75R1-R178) [[4]](diffhunk://#diff-a52beedecf120322f0a395230bbf16965de57fe3ad9f6843499c7569105a306bR5-R19) [[5]](diffhunk://#diff-a52beedecf120322f0a395230bbf16965de57fe3ad9f6843499c7569105a306bR186-R200) [[6]](diffhunk://#diff-ac2d2298ba46bea5f62478ee8c5738d63a8618279629788dbcbf4595c130f5bbR5-R6)

These changes improve the flexibility and robustness of string and boolean handling in Pydantic models, especially when dealing with data that may use empty strings or string-encoded booleans.