### PR TITLE
Fix validators to raise ValueError instead of TypeError for Pydantic …

### DIFF
--- a/pydantictypes/_validation_utils.py
+++ b/pydantictypes/_validation_utils.py
@@ -19,7 +19,7 @@ def validate_optional_string_type(value: Any) -> str | None:  # noqa: ANN401
         The validated string or None if the value is None or empty string.
 
     Raises:
-        TypeError: If value is not None or a string.
+        ValueError: If value is not None or a string.
     """
     # Handle None before type check
     if value is None:
@@ -27,7 +27,8 @@ def validate_optional_string_type(value: Any) -> str | None:  # noqa: ANN401
 
     if not isinstance(value, str):
         msg = f"String required. Value is {value}. Type is {type(value)}."
-        raise TypeError(msg)
+        # Reason: must be ValueError: Pydantic v2 only wraps ValueError into ValidationError; otherwise TypeError propagates to the caller uncaught by Pydantic
+        raise ValueError(msg)  # noqa: TRY004
 
     if value == "":
         return None

--- a/pydantictypes/validators.py
+++ b/pydantictypes/validators.py
@@ -12,7 +12,8 @@ def optional_strict_int_validator(value: Any) -> int | None:  # noqa: ANN401
         return None
     if not isinstance(value, int) or isinstance(value, bool):
         msg = "value is not a valid integer"
-        raise TypeError(msg)
+        # Reason: must be ValueError: Pydantic v2 only wraps ValueError into ValidationError; otherwise TypeError propagates to the caller uncaught by Pydantic
+        raise ValueError(msg)  # noqa: TRY004
     return value
 
 
@@ -29,5 +30,6 @@ def string_validator(value: Any) -> str:  # noqa: ANN401
     """Validate that value is a string."""
     if not isinstance(value, str):
         msg = "string required"
-        raise TypeError(msg)
+        # Reason: must be ValueError: Pydantic v2 only wraps ValueError into ValidationError; otherwise TypeError propagates to the caller uncaught by Pydantic
+        raise ValueError(msg)  # noqa: TRY004
     return value

--- a/tests/pydantictypes/__init__.py
+++ b/tests/pydantictypes/__init__.py
@@ -38,8 +38,8 @@ class BaseTestOptionalType(ABC):
 
     # Reason: Test helper must accept Any type to test various invalid input types
     def _assert_error_raised(self, value: Any) -> None:  # noqa: ANN401
-        """Assert that creating a Stub with the value raises ValidationError or TypeError."""
-        with pytest.raises((ValidationError, TypeError)):
+        """Assert that creating a Stub with the value raises ValidationError."""
+        with pytest.raises(ValidationError):
             create(self.Stub, [value])
 
 

--- a/tests/pydantictypes/test_abstract_string_to_optional_int.py
+++ b/tests/pydantictypes/test_abstract_string_to_optional_int.py
@@ -84,11 +84,11 @@ class TestOptionalIntegerMustBeFromStr:
     )
     # Reason: Need Any to test various non-string types  # pylint: disable-next=line-too-long
     def test_validate_with_non_string_raises_type_error(self, non_string_value: Any, expected_type_name: str) -> None:  # noqa: ANN401
-        """Test that validate raises TypeError for non-string input."""
+        """Test that validate raises ValueError for non-string input."""
         mock_converter = Mock()
         validator = OptionalIntegerMustBeFromStr(mock_converter)
 
-        with pytest.raises(TypeError) as exc_info:
+        with pytest.raises(ValueError, match="String required") as exc_info:
             validator.validate(non_string_value)
 
         error_message = str(exc_info.value)
@@ -346,7 +346,7 @@ class TestAbstractModuleIntegration:
             ("456", 456, False, None),
             ("", None, False, None),
             ("fail", None, True, ValueError),
-            (123, None, True, TypeError),
+            (123, None, True, ValueError),
         ],
     )
     # Reason: Parametrized argument
@@ -380,8 +380,9 @@ class TestAbstractModuleIntegration:
     ) -> None:
         """Helper method to assert that the correct exception is raised."""
         if exception_type is ValueError:
-            with pytest.raises(ValueError, match="Conversion failed"):
-                validator.validate(test_input)
-        elif exception_type is TypeError:
-            with pytest.raises(TypeError, match="String required"):
-                validator.validate(test_input)
+            if isinstance(test_input, str):
+                with pytest.raises(ValueError, match="Conversion failed"):
+                    validator.validate(test_input)
+            else:
+                with pytest.raises(ValueError, match="String required"):
+                    validator.validate(test_input)

--- a/tests/pydantictypes/test_validators.py
+++ b/tests/pydantictypes/test_validators.py
@@ -44,8 +44,8 @@ class TestOptionalStrictIntValidator:
         ],
     )
     def test_with_string_int_raises_error(self, value: str) -> None:
-        """Test that string integer input raises TypeError in strict mode."""
-        with pytest.raises(TypeError):
+        """Test that string integer input raises ValueError in strict mode."""
+        with pytest.raises(ValueError, match="value is not a valid integer"):
             optional_strict_int_validator(value)
 
     @pytest.mark.parametrize(
@@ -57,8 +57,8 @@ class TestOptionalStrictIntValidator:
         ],
     )
     def test_with_float_raises_error(self, value: float) -> None:
-        """Test that float input raises TypeError in strict mode."""
-        with pytest.raises(TypeError):
+        """Test that float input raises ValueError in strict mode."""
+        with pytest.raises(ValueError, match="value is not a valid integer"):
             optional_strict_int_validator(value)
 
     @pytest.mark.parametrize(
@@ -70,8 +70,8 @@ class TestOptionalStrictIntValidator:
     )
     # Reason: Parametrized argument
     def test_with_bool_raises_error(self, value: bool) -> None:  # noqa: FBT001
-        """Test that boolean input raises TypeError in strict mode."""
-        with pytest.raises(TypeError):
+        """Test that boolean input raises ValueError in strict mode."""
+        with pytest.raises(ValueError, match="value is not a valid integer"):
             optional_strict_int_validator(value)
 
 
@@ -182,9 +182,9 @@ class TestStringValidator:
             5.5,
         ],
     )
-    def test_with_non_string_raises_type_error(self, value: object) -> None:
-        """Test that non-string input raises TypeError."""
-        with pytest.raises(TypeError, match="string required"):
+    def test_with_non_string_raises_value_error(self, value: object) -> None:
+        """Test that non-string input raises ValueError."""
+        with pytest.raises(ValueError, match="string required"):
             string_validator(value)
 
 


### PR DESCRIPTION
This pull request updates the custom validators and their tests to ensure that all type validation errors raise `ValueError` instead of `TypeError`. This change is necessary because Pydantic v2 only wraps `ValueError` into its `ValidationError`, while `TypeError` propagates uncaught. The test suite and error messages are also updated to expect `ValueError` in these cases.

Validator error handling changes:

* Changed all custom validators (`validate_optional_string_type`, `optional_strict_int_validator`, and `string_validator`) to raise `ValueError` instead of `TypeError` for invalid input types, with explanatory comments about Pydantic v2's error handling. [[1]](diffhunk://#diff-f61bc93ba1609f87f4a0605060c491ff6169bf856a3fa74ad9966f825122ea03L22-R31) [[2]](diffhunk://#diff-7c3e4295517b9da5493410286d3bd7d0642064d8d98f241bd0abd09bad50c351L15-R16) [[3]](diffhunk://#diff-7c3e4295517b9da5493410286d3bd7d0642064d8d98f241bd0abd09bad50c351L32-R34)

Test updates for new error expectations:

* Updated all relevant tests to expect `ValueError` instead of `TypeError` when invalid types are provided, including updating error messages and test helper logic. [[1]](diffhunk://#diff-46d783e7d95bf23e670155ed854e7c98cd429a068e7c263266c0e4e210215df6L41-R42) [[2]](diffhunk://#diff-ad153cdf4f602e6b39e4340dccd81da67ea52709d9a364b83350430d5c9ad629L87-R91) [[3]](diffhunk://#diff-ad153cdf4f602e6b39e4340dccd81da67ea52709d9a364b83350430d5c9ad629L349-R349) [[4]](diffhunk://#diff-ad153cdf4f602e6b39e4340dccd81da67ea52709d9a364b83350430d5c9ad629R383-R387) [[5]](diffhunk://#diff-94509e6d4a95d62493e9e73f9dba4fe715a625fe2cee933a6a072d6617ddcb42L47-R48) [[6]](diffhunk://#diff-94509e6d4a95d62493e9e73f9dba4fe715a625fe2cee933a6a072d6617ddcb42L60-R61) [[7]](diffhunk://#diff-94509e6d4a95d62493e9e73f9dba4fe715a625fe2cee933a6a072d6617ddcb42L73-R74) [[8]](diffhunk://#diff-94509e6d4a95d62493e9e73f9dba4fe715a625fe2cee933a6a072d6617ddcb42L185-R187)…v2 compatibility

Pydantic v2 only catches ValueError (not TypeError) in BeforeValidator functions and wraps it into ValidationError. Raising TypeError caused it to propagate uncaught to callers. Updated all validators and tests accordingly.